### PR TITLE
Allow full filename including extension to be specified as parameter to vspviewer

### DIFF
--- a/src/vsp_aero/viewer/glviewer.C
+++ b/src/vsp_aero/viewer/glviewer.C
@@ -244,7 +244,10 @@ void GL_VIEWER::LoadInitialData(char *name)
 
     // Determine if an adb file exists
     
-    sprintf(file_name_w_ext,"%s.adb",file_name);
+    if (strstr(file_name,".adb") )    
+        sprintf(file_name_w_ext,"%s",file_name);
+    else
+        sprintf(file_name_w_ext,"%s.adb",file_name);
 
     if ( (adb_file = fopen(file_name_w_ext,"rb")) != NULL ) {
      
@@ -416,7 +419,10 @@ void GL_VIEWER::LoadMeshData(void)
 
     // Open the aerothermal data base file
 
-    sprintf(file_name_w_ext,"%s.adb",file_name);
+    if (strstr(file_name,".adb") )    
+        sprintf(file_name_w_ext,"%s",file_name);
+    else
+        sprintf(file_name_w_ext,"%s.adb",file_name);
 
     if ( (adb_file = fopen(file_name_w_ext,"rb")) == NULL ) {
 
@@ -725,7 +731,10 @@ void GL_VIEWER::LoadSolutionCaseList(void)
     
     // Open the solution case list
 
-    sprintf(file_name_w_ext,"%s.adb.cases",file_name);
+    if (strstr(file_name,".adb") )    
+        sprintf(file_name_w_ext,"%s.cases",file_name);
+    else
+        sprintf(file_name_w_ext,"%s.adb.cases",file_name);
 
     if ( (adb_file = fopen(file_name_w_ext,"r")) == NULL ) {
 
@@ -815,7 +824,10 @@ void GL_VIEWER::LoadExistingSolutionData(int Case)
 
     // Open the aerothermal data base file
 
-    sprintf(file_name_w_ext,"%s.adb",file_name);
+    if (strstr(file_name,".adb") )    
+        sprintf(file_name_w_ext,"%s",file_name);
+    else
+        sprintf(file_name_w_ext,"%s.adb",file_name);
 
     if ( (adb_file = fopen(file_name_w_ext,"rb")) == NULL ) {
 


### PR DESCRIPTION
To allow for operation with the full filename as a command line parameter by only appending ".adb" when not present in the name. This will allow application associations (i.e. double click) to open the ADB file for viewing (Win32)
