### PR TITLE
Minor fixes

### DIFF
--- a/src/geom_core/VSPAEROMgr.cpp
+++ b/src/geom_core/VSPAEROMgr.cpp
@@ -1327,11 +1327,11 @@ string VSPAEROMgrSingleton::ComputeSolverSingle( FILE * logFile )
                     vector<string> args;
                     // Set mach, alpha, beta (save to local "current*" variables to use as header information in the results manager)
                     args.push_back( "-fs" );       // "freestream" override flag
-                    args.push_back( StringUtil::double_to_string( current_mach, "%f" ) );
+                    args.push_back( StringUtil::double_to_string( current_mach, "%.2f" ) );
                     args.push_back( "END" );
-                    args.push_back( StringUtil::double_to_string( current_alpha, "%f" ) );
+                    args.push_back( StringUtil::double_to_string( current_alpha, "%.3f" ) );
                     args.push_back( "END" );
-                    args.push_back( StringUtil::double_to_string( current_beta, "%f" ) );
+                    args.push_back( StringUtil::double_to_string( current_beta, "%.3f" ) );
                     args.push_back( "END" );
                     // Set number of openmp threads
                     args.push_back( "-omp" );
@@ -1522,19 +1522,19 @@ string VSPAEROMgrSingleton::ComputeSolverBatch( FILE * logFile )
         // Mach
         for ( int iMach = 0; iMach < machVec.size(); iMach++ )
         {
-            args.push_back( StringUtil::double_to_string( machVec[iMach], "%f " ) );
+            args.push_back( StringUtil::double_to_string( machVec[iMach], "%.2f" ) );
         }
         args.push_back( "END" );
         // Alpha
         for ( int iAlpha = 0; iAlpha < alphaVec.size(); iAlpha++ )
         {
-            args.push_back( StringUtil::double_to_string( alphaVec[iAlpha], "%f " ) );
+            args.push_back( StringUtil::double_to_string( alphaVec[iAlpha], "%.3f" ) );
         }
         args.push_back( "END" );
         // Beta
         for ( int iBeta = 0; iBeta < betaVec.size(); iBeta++ )
         {
-            args.push_back( StringUtil::double_to_string( betaVec[iBeta], "%f " ) );
+            args.push_back( StringUtil::double_to_string( betaVec[iBeta], "%.3f" ) );
         }
         args.push_back( "END" );
 

--- a/src/vsp_aero/viewer/glviewer.C
+++ b/src/vsp_aero/viewer/glviewer.C
@@ -254,9 +254,12 @@ void GL_VIEWER::LoadInitialData(char *name)
 
     sprintf(file_name,"%s",name);
 
-    // Determine if an adb file exists
+    // Determine if an adb file exists. Add the .adb extension if not already present.
     
-    sprintf(file_name_w_ext,"%s.adb",file_name);
+    if (strstr(file_name,".adb") )    
+        sprintf(file_name_w_ext,"%s",file_name);
+    else
+        sprintf(file_name_w_ext,"%s.adb",file_name);
 
     if ( (adb_file = fopen(file_name_w_ext,"rb")) != NULL ) {
      
@@ -422,9 +425,12 @@ void GL_VIEWER::LoadMeshData(void)
 
     if ( ByteSwapForADB ) BIO.TurnByteSwapForReadsOn();
 
-    // Open the aerothermal data base file
+    // Open the aerothermal data base file. Add the .adb extension if not already present.
 
-    sprintf(file_name_w_ext,"%s.adb",file_name);
+    if (strstr(file_name,".adb") )    
+        sprintf(file_name_w_ext,"%s",file_name);
+    else
+        sprintf(file_name_w_ext,"%s.adb",file_name);
 
     if ( (adb_file = fopen(file_name_w_ext,"rb")) == NULL ) {
 
@@ -1035,9 +1041,12 @@ void GL_VIEWER::LoadSolutionCaseList(void)
     char file_name_w_ext[2000], DumChar[2000];
     FILE *adb_file;
     
-    // Open the solution case list
+    // Open the solution case list. Add the .adb extension if not already present.
 
-    sprintf(file_name_w_ext,"%s.adb.cases",file_name);
+    if (strstr(file_name,".adb") )    
+        sprintf(file_name_w_ext,"%s.cases",file_name);
+    else
+        sprintf(file_name_w_ext,"%s.adb.cases",file_name);
 
     if ( (adb_file = fopen(file_name_w_ext,"r")) == NULL ) {
 
@@ -1156,9 +1165,12 @@ void GL_VIEWER::LoadExistingSolutionData(int Case)
 
     if ( ByteSwapForADB ) BIO.TurnByteSwapForReadsOn();
 
-    // Open the aerothermal data base file
+    // Open the aerothermal data base file. Add the .adb extension if not already present.
 
-    sprintf(file_name_w_ext,"%s.adb",file_name);
+    if (strstr(file_name,".adb") )    
+        sprintf(file_name_w_ext,"%s",file_name);
+    else
+        sprintf(file_name_w_ext,"%s.adb",file_name);
 
     if ( (adb_file = fopen(file_name_w_ext,"rb")) == NULL ) {
 


### PR DESCRIPTION
- Fix windows double click in VSPViewer
- Use two decimal places for the alpha/beta (etc.) command line parameters to VSPAero to allow more parameters on the command line.
